### PR TITLE
fix last commit for db upgraded

### DIFF
--- a/parity/db/rocksdb/migration.rs
+++ b/parity/db/rocksdb/migration.rs
@@ -224,7 +224,7 @@ pub fn migrate(path: &Path, compaction_profile: &DatabaseCompactionProfile) -> R
         return Ok(());
     }
 
-    if version <= USE_MIGRATION_TOOL {
+    if version != DEFAULT_VERSION && version <= USE_MIGRATION_TOOL {
         return Err(Error::UseMigrationTool);
     }
 


### PR DESCRIPTION
Last commit didn't take into account when the version_db file is not existing and default value is used. On non existing DB it will still print error msg. 