### PR TITLE
Drain the transaction overlay in snapshot (#11654)

### DIFF
--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -499,8 +499,13 @@ impl StateRebuilder {
                 account_trie.insert(&hash, &thin_rlp)?;
             }
         }
-
         trace!(target: "snapshot", "current state root: {:?}", self.state_root);
+
+        let backing = self.db.backing().clone();
+        let mut batch = backing.transaction();
+        // Drain the transaction overlay and put the data into the batch.
+        self.db.inject(&mut batch)?;
+        backing.write_buffered(batch);
         Ok(())
     }
 


### PR DESCRIPTION
This is a backport of  https://github.com/openethereum/openethereum/pull/11654 