### PR TITLE
Add `wasmDisableTransition` spec option

### DIFF
--- a/ethcore/res/ethereum/kovan_wasm_test.json
+++ b/ethcore/res/ethereum/kovan_wasm_test.json
@@ -42,7 +42,8 @@
 		"eip211Transition": 5067000,
 		"eip214Transition": 5067000,
 		"eip658Transition": 5067000,
-		"wasmActivationTransition": 10
+		"wasmActivationTransition": 10,
+		"wasmDisableTransition": 200
 	},
 	"genesis": {
 		"seal": {

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -2919,7 +2919,7 @@ mod tests {
 
         let mut info = EnvInfo::default();
 
-        // 100 > 10
+        // 200 (wasmDisableTransition) > 100 > 10 (wasmActivationTransition)
         info.number = 100;
 
         // Network with wasm activated at block 10
@@ -2947,8 +2947,34 @@ mod tests {
         // Transaction successfully returned sender
         assert_eq!(output[..], sender[..]);
 
-        // 1 < 10
+        // 1 < 10 (wasmActivationTransition)
         info.number = 1;
+
+        let mut output = [0u8; 20];
+        let FinalizationResult {
+            gas_left: result,
+            return_data,
+            ..
+        } = {
+            let schedule = machine.schedule(info.number);
+            let mut ex = Executive::new(&mut state, &info, &machine, &schedule);
+            ex.call(
+                params.clone(),
+                &mut Substate::new(),
+                &mut NoopTracer,
+                &mut NoopVMTracer,
+            )
+            .unwrap()
+        };
+        (&mut output[..(cmp::min(20, return_data.len()))])
+            .copy_from_slice(&return_data[..(cmp::min(20, return_data.len()))]);
+
+        assert_eq!(result, U256::from(20025));
+        // Since transaction errored due to wasm was not activated, result is just empty
+        assert_eq!(output[..], [0u8; 20][..]);
+
+        // 200 == wasmDisableTransition
+        info.number = 200;
 
         let mut output = [0u8; 20];
         let FinalizationResult {
@@ -2970,7 +2996,7 @@ mod tests {
             .copy_from_slice(&return_data[..(cmp::min(20, return_data.len()))]);
 
         assert_eq!(result, U256::from(20025));
-        // Since transaction errored due to wasm was not activated, result is just empty
+        // Since transaction errored due to wasm was deactivated, result is just empty
         assert_eq!(output[..], [0u8; 20][..]);
     }
 }

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -228,7 +228,9 @@ impl CommonParams {
                 false => ::vm::CleanDustMode::BasicOnly,
             };
         }
-        if block_number >= self.wasm_activation_transition && block_number < self.wasm_disable_transition {
+        if block_number >= self.wasm_activation_transition
+            && block_number < self.wasm_disable_transition
+        {
             let mut wasm = ::vm::WasmCosts::default();
             if block_number >= self.kip4_transition {
                 wasm.have_create2 = true;

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -143,6 +143,8 @@ pub struct CommonParams {
     pub remove_dust_contracts: bool,
     /// Wasm activation blocknumber, if any disabled initially.
     pub wasm_activation_transition: BlockNumber,
+    /// Wasm deactivation blocknumber, if enabled.
+    pub wasm_disable_transition: BlockNumber,
     /// Number of first block where KIP-4 rules begin. Only has effect if Wasm is activated.
     pub kip4_transition: BlockNumber,
     /// Number of first block where KIP-6 rules begin. Only has effect if Wasm is activated.
@@ -226,7 +228,7 @@ impl CommonParams {
                 false => ::vm::CleanDustMode::BasicOnly,
             };
         }
-        if block_number >= self.wasm_activation_transition {
+        if block_number >= self.wasm_activation_transition && block_number < self.wasm_disable_transition {
             let mut wasm = ::vm::WasmCosts::default();
             if block_number >= self.kip4_transition {
                 wasm.have_create2 = true;
@@ -361,6 +363,9 @@ impl From<ethjson::spec::Params> for CommonParams {
                 .map_or(0, Into::into),
             wasm_activation_transition: p
                 .wasm_activation_transition
+                .map_or_else(BlockNumber::max_value, Into::into),
+            wasm_disable_transition: p
+                .wasm_disable_transition
                 .map_or_else(BlockNumber::max_value, Into::into),
             kip4_transition: p
                 .kip4_transition
@@ -628,6 +633,7 @@ impl Spec {
             params.eip2315_transition,
             params.dust_protection_transition,
             params.wasm_activation_transition,
+            params.wasm_disable_transition,
             params.kip4_transition,
             params.kip6_transition,
             params.max_code_size_transition,

--- a/json/src/spec/params.rs
+++ b/json/src/spec/params.rs
@@ -132,6 +132,8 @@ pub struct Params {
     pub transaction_permission_contract_transition: Option<Uint>,
     /// Wasm activation block height, if not activated from start
     pub wasm_activation_transition: Option<Uint>,
+    /// Wasm deactivation block height, if activated.
+    pub wasm_disable_transition: Option<Uint>,
     /// KIP4 activiation block height.
     pub kip4_transition: Option<Uint>,
     /// KIP6 activiation block height.
@@ -156,7 +158,8 @@ mod tests {
 			"accountStartNonce": "0x01",
 			"gasLimitBoundDivisor": "0x20",
 			"maxCodeSize": "0x1000",
-			"wasmActivationTransition": "0x1010"
+			"wasmActivationTransition": "0x1010",
+            "wasmDisableTransition": "0x2010"
 		}"#;
 
         let deserialized: Params = serde_json::from_str(s).unwrap();
@@ -174,6 +177,10 @@ mod tests {
         assert_eq!(
             deserialized.wasm_activation_transition,
             Some(Uint(U256::from(0x1010)))
+        );
+        assert_eq!(
+            deserialized.wasm_disable_transition,
+            Some(Uint(U256::from(0x2010)))
         );
     }
 


### PR DESCRIPTION
Adds `wasmDisableTransition` spec option to disable WASM on Kovan on a certain block.

POA Team will need this to avoid splitting the Kovan chain after some Kovan validators replace their node with Nethermind client (which doesn't support WASM).