### PR TITLE
Use ubuntu-16.04 for glibc compatibility (#11888)

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - ubuntu-20.04
+          - ubuntu-16.04
           - macos-latest
           - windows-latest
         toolchain:
@@ -48,7 +48,7 @@ jobs:
           path:                 target
           key:                  ${{ runner.os }}-cargo-build-target-build-tests-${{ hashFiles('**/Cargo.lock') }}
       - name:                   Cache sccache linux
-        if:                     matrix.platform == 'ubuntu-20.04'
+        if:                     matrix.platform == 'ubuntu-16.04'
         uses:                   actions/cache@v2
         with:
           path:                 "/home/runner/.cache/sccache"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 env:
   AWS_REGION:                   "us-east-1"
   AWS_S3_ARTIFACTS_BUCKET:      "openethereum-releases"
-
+      
 jobs:
   build:
     name:                       Build Release
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         platform:
-          - ubuntu-20.04
+          - ubuntu-16.04
           - macos-latest
           - windows-latest
         toolchain:
@@ -52,7 +52,7 @@ jobs:
           path:                 target
           key:                  ${{ runner.os }}-cargo-build-target-build-${{ hashFiles('**/Cargo.lock') }}
       - name:                   Cache sccache linux
-        if:                     matrix.platform == 'ubuntu-20.04'
+        if:                     matrix.platform == 'ubuntu-16.04'
         uses:                   actions/cache@v2
         with:
           path:                 "/home/runner/.cache/sccache"
@@ -105,7 +105,7 @@ jobs:
 
       - name:                   Upload Linux build
         uses:                   actions/upload-artifact@v2
-        if:                     matrix.platform == 'ubuntu-20.04'
+        if:                     matrix.platform == 'ubuntu-16.04'
         with:
           name:                 linux-artifacts
           path:                 artifacts
@@ -132,7 +132,7 @@ jobs:
   zip-artifacts-creator:
     name:                       Create zip artifacts
     needs:                      build
-    runs-on:                    ubuntu-20.04
+    runs-on:                    ubuntu-16.04
     steps:
       - name:                   Set env
         run:                    echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}
@@ -253,7 +253,7 @@ jobs:
   draft-release:
     name:                       Draft Release
     needs:                      zip-artifacts-creator
-    runs-on:                    ubuntu-20.04
+    runs-on:                    ubuntu-16.04
     steps:
       - name:                   Set env
         run:                    echo ::set-env name=RELEASE_VERSION::${GITHUB_REF#refs/*/}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   check:
     name:                       Check
-    runs-on:                    ubuntu-20.04
+    runs-on:                    ubuntu-16.04
     env:
       SCCACHE_CACHE_SIZE:       "1G"
       SCCACHE_IDLE_TIMEOUT:     0    


### PR DESCRIPTION
Reported Issue: Openethereum 3.1rc1 fails - GLIBC_2.29 not found [#11888](https://github.com/openethereum/openethereum/issues/11888)

