### PR TITLE
Sync block verification

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -389,6 +389,8 @@ impl Importer {
 
         let db = client.db.read();
         db.key_value().flush().expect("DB flush failed.");
+
+        self.block_queue.resignal_verification();
         imported
     }
 

--- a/ethcore/src/client/config.rs
+++ b/ethcore/src/client/config.rs
@@ -151,7 +151,7 @@ impl Default for ClientConfig {
             history_mem: 32 * mb,
             check_seal: true,
             transaction_verification_queue_size: 8192,
-            max_round_blocks_to_import: 12,
+            max_round_blocks_to_import: 1,
             snapshot: Default::default(),
         }
     }

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -278,7 +278,7 @@ fn can_handle_long_fork() {
     push_blocks_to_client(&client, 49, 1201, 800);
     push_blocks_to_client(&client, 53, 1201, 600);
 
-    for _ in 0..400 {
+    for _ in 0..2300 {
         client.import_verified_blocks();
     }
     assert_eq!(2000, client.chain_info().best_block_number);

--- a/ethcore/src/verification/queue/mod.rs
+++ b/ethcore/src/verification/queue/mod.rs
@@ -665,11 +665,17 @@ impl<K: Kind> VerificationQueue<K> {
             .verified
             .fetch_sub(drained_size, AtomicOrdering::SeqCst);
 
+        result
+    }
+
+    /// release taken signal and call async ClientIoMessage::BlockVerified call to client so that it can continue verification.
+    /// difference between sync and async is whose thread pool is used.
+    pub fn resignal_verification(&self) {
+        let verified = self.verification.verified.lock();
         self.ready_signal.reset();
         if !verified.is_empty() {
             self.ready_signal.set_async();
         }
-        result
     }
 
     /// Returns true if there is nothing currently in the queue.

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -706,7 +706,7 @@ usage! {
             "--stratum-secret=[STRING]",
             "Secret for authorizing Stratum server for peers.",
 
-            ARG arg_max_round_blocks_to_import: (usize) = 12usize, or |c: &Config| c.mining.as_ref()?.max_round_blocks_to_import.clone(),
+            ARG arg_max_round_blocks_to_import: (usize) = 1usize, or |c: &Config| c.mining.as_ref()?.max_round_blocks_to_import.clone(),
             "--max-round-blocks-to-import=[S]",
             "Maximal number of blocks to import for each import round.",
 
@@ -1386,7 +1386,7 @@ mod tests {
                 arg_notify_work: Some("http://localhost:3001".into()),
                 flag_refuse_service_transactions: false,
                 flag_infinite_pending_block: false,
-                arg_max_round_blocks_to_import: 12usize,
+                arg_max_round_blocks_to_import: 1usize,
 
                 flag_stratum: false,
                 arg_stratum_interface: "local".to_owned(),

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -1369,7 +1369,7 @@ mod tests {
                 check_seal: true,
                 with_color: !cfg!(windows),
                 verifier_settings: Default::default(),
-                max_round_blocks_to_import: 12,
+                max_round_blocks_to_import: 1,
             }))
         );
     }
@@ -1395,7 +1395,7 @@ mod tests {
                 from_block: BlockId::Number(1),
                 to_block: BlockId::Latest,
                 check_seal: true,
-                max_round_blocks_to_import: 12,
+                max_round_blocks_to_import: 1,
             }))
         );
     }
@@ -1423,7 +1423,7 @@ mod tests {
                 code: true,
                 min_balance: None,
                 max_balance: None,
-                max_round_blocks_to_import: 12,
+                max_round_blocks_to_import: 1,
             }))
         );
     }
@@ -1456,7 +1456,7 @@ mod tests {
                 from_block: BlockId::Number(1),
                 to_block: BlockId::Latest,
                 check_seal: true,
-                max_round_blocks_to_import: 12,
+                max_round_blocks_to_import: 1,
             }))
         );
     }
@@ -1550,7 +1550,7 @@ mod tests {
             download_old_blocks: true,
             verifier_settings: Default::default(),
             no_persistent_txqueue: false,
-            max_round_blocks_to_import: 12,
+            max_round_blocks_to_import: 1,
             metrics_conf: MetricsConfiguration::default(),
         };
         expected.secretstore_conf.enabled = cfg!(feature = "secretstore");


### PR DESCRIPTION
- Parallelization of verification that depends on a parent-child relationship can be troublesome this commit removes that and makes that part of the verification sequential.
- Batch executing one by one block was faster on my machine and it made the client more stable.